### PR TITLE
Remove title casing from interface names and remove type test from code gen

### DIFF
--- a/extraction/visitor.go
+++ b/extraction/visitor.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
-	"strings"
 
 	"github.com/efritz/go-mockgen/specs"
 )
@@ -61,7 +60,7 @@ func (v *visitor) visitTypeSpec(typeSpec *ast.TypeSpec) error {
 		Methods: methods,
 	}
 
-	v.specs[title(typeSpec.Name.Name)] = spec
+	v.specs[typeSpec.Name.Name] = spec
 	return nil
 }
 
@@ -97,12 +96,4 @@ func deconstructMethod(signature *types.Signature) *specs.MethodSpec {
 		Results:  results,
 		Variadic: signature.Variadic(),
 	}
-}
-
-func title(s string) string {
-	if s == "" {
-		return s
-	}
-
-	return strings.ToUpper(string(s[0])) + s[1:]
 }

--- a/generation/interface.go
+++ b/generation/interface.go
@@ -52,7 +52,6 @@ func (g *interfaceGenerator) generate() {
 	fns := []func(){
 		g.generateInterfaceDefinition,
 		g.generateParamSetDefinitions,
-		g.generateTypeTest,
 		g.generateConstructor,
 		g.generateMethodImplementations,
 		g.generateDefaultMethodImplementations,
@@ -125,19 +124,6 @@ func (g *interfaceGenerator) generateParamSetDefinition(name string, method *spe
 
 	// type {{Interface}}{{Method}}FuncParamSet struct { [fields] }
 	g.file.Type().Id(structName).Struct(fields...)
-}
-
-//
-// Type Test
-
-func (g *interfaceGenerator) generateTypeTest() {
-	var (
-		pkgName  = stripVendor(g.spec.ImportPath)
-		ctorName = fmt.Sprintf(constructorFormat, g.prefix, g.name)
-	)
-
-	// var _ {{Interface}} = NewMock{{Interface}}()
-	g.file.Var().Id("_").Qual(pkgName, g.name).Op("=").Id(ctorName).Call()
 }
 
 //


### PR DESCRIPTION
I removed the title casing from the interface naming because I think it's confusing.  I originally put -i uplinkProcessor for my interface name but it kept telling me it couldn't find it. I ended up trying UplinkProcessor, which worked.  I think it adds confusion (and inhibits discoverability) if the command line parameters are different than the code itself.

I also removed the type test in the generated code because it was causing import loops in my mocks.  I have my interface in uplink/uplink.go, for example, and the generated code in uplink/mock/*.go.  If I try importing the mock in uplink/uplink_test.go it will create an import loop because the mock imports the initial package.  I can see the desire for having the type check but I think it should be fine to exclude it because any code that's using it (likely within the same app/lib with the mock) will be type checked just by creating the mock.  If someone wants the type check for something else they could just create a file in the mock package that does the type check "manually".